### PR TITLE
add argument for i/o autoscaling in MySQL flex server

### DIFF
--- a/examples/full_main.tf
+++ b/examples/full_main.tf
@@ -17,7 +17,8 @@ module "database" {
       version                = "8.0.21"
       zone                   = "1"
       storage = {
-        size_gb = 20
+        io_scaling_enabled = true
+        size_gb            = 20
       }
       high_availability = {
         mode                      = "ZoneRedundant"

--- a/main.tf
+++ b/main.tf
@@ -69,9 +69,10 @@ resource "azurerm_mysql_flexible_server" "mysql_flexible_server" {
     for_each = length(compact(values(local.mysql_flexible_server[each.key].storage))) > 0 ? [0] : []
 
     content {
-      auto_grow_enabled = local.mysql_flexible_server[each.key].storage.auto_grow_enabled
-      iops              = local.mysql_flexible_server[each.key].storage.iops
-      size_gb           = local.mysql_flexible_server[each.key].storage.size_gb
+      auto_grow_enabled  = local.mysql_flexible_server[each.key].storage.auto_grow_enabled
+      io_scaling_enabled = local.mysql_flexible_server[each.key].storage.io_scaling_enabled
+      iops               = local.mysql_flexible_server[each.key].storage.iops
+      size_gb            = local.mysql_flexible_server[each.key].storage.size_gb
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -76,9 +76,10 @@ locals {
         start_minute = null
       }
       storage = {
-        auto_grow_enabled = null
-        iops              = null
-        size_gb           = null
+        auto_grow_enabled  = null
+        io_scaling_enabled = null
+        iops               = null
+        size_gb            = null
       }
       tags = {}
     }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = ">=3.57.0, <4.0"
+      version = ">=3.75.0, <4.0"
     }
   }
   required_version = ">=1.3"


### PR DESCRIPTION
The io_scaling_enabled argument can be used to control the I/O autoscaling of a MySQL flexible server (see https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mysql_flexible_server#io_scaling_enabled). This argument is only available from AzureRM provider version 3.75.0, so I have adapted the necessary version.
I have also expanded the detailed example to include this argument.